### PR TITLE
Fixes 'get started' instructions with more standard go conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Mirrors hosted by [SmartPAN](smartpan/README.md) are fully Carton/cpanm compatib
 but also support the `SmartPAN` interface used by [GetPAN](getpan/README.md).
 
 [GetPAN](getpan/README.md) is also Carton/cpanm compatible and works with CPAN, BackPAN,
-and DarkPAN mirrors using Pinto and Orepan. 
+and DarkPAN mirrors using Pinto and Orepan.
 
 When used with [SmartPAN](smartpan/README.md),
-the `SmartPAN` interface fixes dependency resolution issues which exist with typical CPAN 
+the `SmartPAN` interface fixes dependency resolution issues which exist with typical CPAN
 indexes.
 
 | Application                    | Description
@@ -31,11 +31,13 @@ You need Perl (preferably >=5.18.2) and the following modules for indexing
 - Parse::LocalDistribution
 - JSON::XS
 
-### Setting up 
- - `cd $GOPATH/src/github.com/companieshouse/`
- - `git clone git@github.com:companieshouse/gopan.git`
- - `cd gopan`
- - `make`
+### Setting up
+
+```bash
+$ go get github.com/companieshouse/gopan
+$ cd $GOPATH/src/github.com/companieshouse/gopan
+$ make
+```
 
 Use getpan to simplify installation:
 


### PR DESCRIPTION
Should `go get` really for a go package rather than `git clone`
