### PR TITLE
Fix concurrent map read and map write in dependency toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.10
+VERSION = 0.11
 
 all: deps install fmt
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.11
+VERSION = 0.12
 
 all: deps install fmt
 

--- a/smartpan/main.go
+++ b/smartpan/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ian-kent/go-log/log"
 )
 
-var CurrentRelease = "0.11"
+var CurrentRelease = "0.12"
 
 type Releases []*Release
 type Release struct {

--- a/smartpan/main.go
+++ b/smartpan/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ian-kent/go-log/log"
 )
 
-var CurrentRelease = "0.10"
+var CurrentRelease = "0.11"
 
 type Releases []*Release
 type Release struct {


### PR DESCRIPTION
This change introduces a fix for build failures due to concurrent map reading and map writing, in addition to a version bump in preparation for release.